### PR TITLE
fix bug) set digest by params to concat original query string in uploadUrl and digest

### DIFF
--- a/dockertarpusher/dockertarpusher.py
+++ b/dockertarpusher/dockertarpusher.py
@@ -174,7 +174,7 @@ class Registry:
             try:
                 self.conditionalPrint("Pushing... " + str(round((offset / content_size) * 100, 2)) + "%  ", end="\r" )
                 if(last):
-                    r = requests.put(uploadUrl + "&digest=sha256:" + str(sha256hash.hexdigest()), data=chunk, headers=headers, auth = self.auth, verify = self.sslVerify)
+                    r = requests.put(uploadUrl, data=chunk, headers=headers, auth = self.auth, verify = self.sslVerify, params={"digest": "sha256:" + str(sha256hash.hexdigest())})
                 else:
                     r = requests.patch(uploadUrl, data=chunk, headers=headers, auth = self.auth, verify = self.sslVerify)
                     if("Location" in r.headers):


### PR DESCRIPTION
chunkedUpload failed when uploadUrl (which is specified by registry server) does not contain query string parameter.

When uploadUrl does not contain query string, adding digest in query string should be like `+ '?digest=`, because digest is first query string parameter.
To make it easy to handling parameter, use `params` of requests.
It preserve original query string in url as shown in below.
 * https://github.com/psf/requests/blob/5e749546a26ce62e53d0a14ae1455f8b066fe19f/requests/models.py#L390
 * https://github.com/psf/requests/blob/5e749546a26ce62e53d0a14ae1455f8b066fe19f/requests/models.py#L445
