### PR TITLE
fix typo of auth

### DIFF
--- a/dockertarpusher/dockertarpusher.py
+++ b/dockertarpusher/dockertarpusher.py
@@ -146,7 +146,7 @@ class Registry:
             yield data
 
     def setAuth(self, authObj):
-        self.atuh = authObj
+        self.auth = authObj
 
     def chunkedUpload(self, file, url):
         content_name = str(file)


### PR DESCRIPTION
Noticed this typo, will cause a problem if using the setAuth method.